### PR TITLE
Pull upgrades into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ EXPOSE 4567
 COPY Gemfile .
 COPY Gemfile.lock .
 
-RUN apt-get update \
+RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         build-essential \
         nodejs \


### PR DESCRIPTION
## What?
Add `apt-get upgrade -y` to Dockerfile.

## Why?
It is almost always best practice to pull security upgrades in Dockerfiles.

## Note to Reviewer(s)
If there is a legitimate reason to not pull in updates & upgrades for this Dockerfile please make note of the reasoning and I will add an exception for this repo.

## Reference
https://pythonspeed.com/articles/security-updates-in-docker/