### PR TITLE
Upgrading middleman to 4.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ ruby "3.3.6"
 source "https://rubygems.org"
 
 # Middleman
-gem "middleman", "~>4.4"
-gem "middleman-syntax", "~> 3.2"
+gem "middleman", "~>4.5"
+gem "middleman-syntax", "~> 3.4"
 gem "middleman-autoprefixer", "~> 3.0"
 gem "middleman-sprockets", "~> 4.1"
 gem "rouge", "~> 3.21"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     middleman-sprockets (4.1.1)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
-    middleman-syntax (3.3.0)
+    middleman-syntax (3.4.0)
       middleman-core (>= 3.2)
       rouge (~> 3.2)
     mini_portile2 (2.8.2)
@@ -127,10 +127,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman (~> 4.4)
+  middleman (~> 4.5)
   middleman-autoprefixer (~> 3.0)
   middleman-sprockets (~> 4.1)
-  middleman-syntax (~> 3.2)
+  middleman-syntax (~> 3.4)
   nokogiri (~> 1.14.3)
   redcarpet (~> 3.5.0)
   rouge (~> 3.21)


### PR DESCRIPTION
Upgrade middleman to 4.5 in preparation for a Rails 7.1 upgrade on docs-rails.