### PR TITLE
Upgrading last middleman dependency for Rails 7.1 upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ ruby "3.3.6"
 source "https://rubygems.org"
 
 # Middleman
-gem "middleman", "~>4.5"
+gem "middleman", "~>4.5.1"
 gem "middleman-syntax", "~> 3.4"
 gem "middleman-autoprefixer", "~> 3.0"
 gem "middleman-sprockets", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,14 +16,14 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.2)
-    contracts (0.17)
+    contracts (0.16.1)
     dotenv (2.8.1)
     erubis (2.7.0)
     execjs (2.8.1)
     fast_blank (1.0.1)
     fastimage (2.2.6)
     ffi (1.15.5)
-    haml (6.1.1)
+    haml (6.3.0)
       temple (>= 0.8.2)
       thor
       tilt
@@ -32,29 +32,29 @@ GEM
     hashie (3.6.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     memoist (0.16.2)
-    middleman (4.5.0)
+    middleman (4.5.1)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
       kramdown (>= 2.3.0)
-      middleman-cli (= 4.5.0)
-      middleman-core (= 4.5.0)
+      middleman-cli (= 4.5.1)
+      middleman-core (= 4.5.1)
     middleman-autoprefixer (3.0.0)
       autoprefixer-rails (~> 10.0)
       middleman-core (>= 4.0.0)
-    middleman-cli (4.5.0)
-      thor (>= 0.17.0, < 2.0)
-    middleman-core (4.5.0)
+    middleman-cli (4.5.1)
+      thor (>= 0.17.0, < 1.3.0)
+    middleman-core (4.5.1)
       activesupport (>= 6.1, < 7.1)
       addressable (~> 2.4)
       backports (~> 3.6)
       bundler (~> 2.0)
-      contracts (~> 0.13)
+      contracts (~> 0.13, < 0.17)
       dotenv
       erubis
       execjs (~> 2.0)
@@ -99,7 +99,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.1)
-    rexml (3.3.9)
+    rexml (3.4.0)
     rouge (3.30.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -112,7 +112,7 @@ GEM
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    temple (0.10.1)
+    temple (0.10.3)
     thor (1.2.2)
     tilt (2.0.11)
     toml (0.3.0)
@@ -127,7 +127,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman (~> 4.5)
+  middleman (~> 4.5.1)
   middleman-autoprefixer (~> 3.0)
   middleman-sprockets (~> 4.1)
   middleman-syntax (~> 3.4)
@@ -140,4 +140,4 @@ RUBY VERSION
    ruby 3.3.6p108
 
 BUNDLED WITH
-   2.3.9
+   2.5.9


### PR DESCRIPTION
Updating the last Slate dependency so that we can upgrade `docs-rails` to Rails 7.1.

As always, this change will be tested as part of the changes in `docs-rails`.