### PR TITLE
chore:Upgrade nokogiri to 1.18.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       rouge (~> 3.2)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
-    nokogiri (1.18.4)
+    nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     padrino-helpers (0.15.3)


### PR DESCRIPTION
## What did we change?
Upgrade nokogiri to 1.18.8.

## Why did we make this change?
Address a security vulnerability that is resolved in this more recent version of this gem.