### PR TITLE
chore:Update rack version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     parslet (2.0.0)
     public_suffix (5.0.1)
     racc (1.8.1)
-    rack (2.2.13)
+    rack (2.2.17)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)


### PR DESCRIPTION
## What did we change?
Updating the version of rack used in this repo

## Why did we make this change?
 Addressing [this](https://github.com/ezcater/slate/security/dependabot/43) vulnerability, which we were notified about through security.